### PR TITLE
Resolve #19 Use Div for Max-Width

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,8 @@
     <link rel="stylesheet" href="{{ site.url }}/css/main.css">
   </head>
   <body>
+    <div class="container">
     {{ content }}
+    </div>
   </body>
 </html>

--- a/_sass/front.scss
+++ b/_sass/front.scss
@@ -4,13 +4,8 @@ $phone: "(max-width: 768px)";
 
 body {
   font-family: 'Roboto', sans-serif;
-  margin: 0 auto;
-  width: 16em;
   font-size: 16px;
   color: #002D40;
-  @media #{$desktop} {
-    width: 73em;
-  }
 }
 
 h1 {
@@ -45,6 +40,14 @@ button {
   position: relative;
   @media #{$desktop} {
     padding: 2em 5em;
+  }
+}
+
+.container {
+  margin: 0 auto;
+  width: 16em;
+  @media #{$desktop} {
+    width: 73em;
   }
 }
 

--- a/_sass/municipality.scss
+++ b/_sass/municipality.scss
@@ -1,4 +1,4 @@
-.container {
+.mayor-container {
   @media #{$desktop} {
     display: flex;
   }

--- a/municipalities/arlington.html
+++ b/municipalities/arlington.html
@@ -3,7 +3,7 @@ layout: default
 title: Arlington
 ---
 <h1>Arlington</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/arlington.png" | relative_url }}">
     <figcaption></figcaption>

--- a/municipalities/boston.html
+++ b/municipalities/boston.html
@@ -3,7 +3,7 @@ layout: default
 title: Boston
 ---
 <h1>Boston</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/boston.png" | relative_url }}">
     <figcaption>Mayor Marty Walsh</figcaption>

--- a/municipalities/braintree.html
+++ b/municipalities/braintree.html
@@ -3,7 +3,7 @@ layout: default
 title: Braintree
 ---
 <h1>Braintree</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/braintree.png" | relative_url }}">
     <figcaption></figcaption>

--- a/municipalities/brookline.html
+++ b/municipalities/brookline.html
@@ -3,7 +3,7 @@ layout: default
 title: Brookline
 ---
 <h1>Brookline</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/brookline.png" | relative_url }}">
     <figcaption></figcaption>

--- a/municipalities/cambridge.html
+++ b/municipalities/cambridge.html
@@ -3,7 +3,7 @@ layout: default
 title: Cambridge
 ---
 <h1>Cambridge</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/cambridge.png" | relative_url }}">
     <figcaption>Mayor Marc C. McGovern</figcaption>

--- a/municipalities/chelsea.html
+++ b/municipalities/chelsea.html
@@ -3,7 +3,7 @@ layout: default
 title: Chelsea
 ---
 <h1>Chelsea</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/chelsea.png" | relative_url }}">
     <figcaption></figcaption>

--- a/municipalities/everett.html
+++ b/municipalities/everett.html
@@ -3,7 +3,7 @@ layout: default
 title: Everett
 ---
 <h1>Everett</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/Everett.png" | relative_url }}">
     <figcaption>Mayor Carlo DeMaria, Jr.</figcaption>

--- a/municipalities/malden.html
+++ b/municipalities/malden.html
@@ -3,7 +3,7 @@ layout: default
 title: Malden
 ---
 <h1>Malden</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/Malden.png" | relative_url }}">
     <figcaption>Mayor Gary Christenson</figcaption>

--- a/municipalities/medford.html
+++ b/municipalities/medford.html
@@ -3,7 +3,7 @@ layout: default
 title: Medford
 ---
 <h1>Medford</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/reardon.jpg" | relative_url }}">
     <figcaption>Mayor Marty Walsh</figcaption>

--- a/municipalities/melrose.html
+++ b/municipalities/melrose.html
@@ -3,7 +3,7 @@ layout: default
 title: Melrose
 ---
 <h1>Melrose</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/melrose.png" | relative_url }}">
     <figcaption>Mayor Gail Infurna</figcaption>

--- a/municipalities/newton.html
+++ b/municipalities/newton.html
@@ -3,7 +3,7 @@ layout: default
 title: Newton
 ---
 <h1>Newton</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/newton.png" | relative_url }}">
     <figcaption>Mayor Fuller</figcaption>

--- a/municipalities/quincy.html
+++ b/municipalities/quincy.html
@@ -3,7 +3,7 @@ layout: default
 title: Quincy
 ---
 <h1>Quincy</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/quincy.png" | relative_url }}">
     <figcaption></figcaption>

--- a/municipalities/revere.html
+++ b/municipalities/revere.html
@@ -3,7 +3,7 @@ layout: default
 title: Revere
 ---
 <h1>Revere</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/revere.png" | relative_url }}">
     <figcaption></figcaption>

--- a/municipalities/somerville.html
+++ b/municipalities/somerville.html
@@ -3,7 +3,7 @@ layout: default
 title: Somerville
 ---
 <h1>Somerville</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/somerville.png" | relative_url }}">
     <figcaption>Mayor Marty Walsh</figcaption>

--- a/municipalities/winthrop.html
+++ b/municipalities/winthrop.html
@@ -3,7 +3,7 @@ layout: default
 title: Winthrop
 ---
 <h1>Winthrop</h1>
-<div class="container">
+<div class="mayor-container">
   <figure>
     <img class="mayor" src="{{ "/images/reardon.jpg" | relative_url }}">
     <figcaption>Mayor Marty Walsh</figcaption>


### PR DESCRIPTION
Instead of styling the body with max-width this commit styles a div and then moves the mayor div which acts differently into a sub-container.